### PR TITLE
Fix docstring closing

### DIFF
--- a/IsotopeFractionationModel/BasicUtility.py
+++ b/IsotopeFractionationModel/BasicUtility.py
@@ -98,8 +98,7 @@ def mixing_ratio_to_specific_humidity(w1000: float) -> float:
     
     Returns
     - float: Specific humidity (g/kg).
-    """""
-    
+    """
     w = w1000 / 1000
     q = w / (1 + w)
     return q * 1000


### PR DESCRIPTION
## Summary
- repair closing quotes in `mixing_ratio_to_specific_humidity`
- remove blank line so function body begins immediately after the docstring

## Testing
- `python -m py_compile IsotopeFractionationModel/BasicUtility.py`

------
https://chatgpt.com/codex/tasks/task_b_6852604766288326a7717b32bc2da858