### PR TITLE
Fix docstring typo

### DIFF
--- a/IsotopeFractionationModel/KineticFractionation.py
+++ b/IsotopeFractionationModel/KineticFractionation.py
@@ -137,7 +137,7 @@ def plot_kin_frac_factor(
     Methods:
     - Split the temperature range into positive and negative subsets.
     - For each isotope type:
-        - Caluclate and plot kinetic fractionation factors for ice for negative temperatures
+        - Calculate and plot kinetic fractionation factors for ice for negative temperatures
           using `kin_frac_factor_ice`.
         - Calculate and plot kinetic fractionation factor for sea surface evaporation factors for positive temperatures
           using `kin_frac_factor_sea_evap`.


### PR DESCRIPTION
## Summary
- correct spelling of "Calculate" in kinetic fractionation docstring

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_68526036d2a48326b1b5c08f188cf763